### PR TITLE
Add CONFIG_SCHEMA for UVR64 DLBus

### DIFF
--- a/components/uvr64_dlbus/__init__.py
+++ b/components/uvr64_dlbus/__init__.py
@@ -1,0 +1,10 @@
+from .sensor.uvr64_dlbus import (
+    CONF_TEMPERATURES,
+    CONF_RELAYS,
+    UVR64DLBusSensor,
+    CONFIG_SCHEMA,
+    to_code,
+)
+
+DEPENDENCIES = ["uart"]
+AUTO_LOAD = ["sensor"]

--- a/components/uvr64_dlbus/sensor/__init__.py
+++ b/components/uvr64_dlbus/sensor/__init__.py
@@ -1,0 +1,7 @@
+from .uvr64_dlbus import (
+    CONF_TEMPERATURES,
+    CONF_RELAYS,
+    UVR64DLBusSensor,
+    CONFIG_SCHEMA,
+    to_code,
+)


### PR DESCRIPTION
## Summary
- expose CONFIG_SCHEMA and to_code for `uvr64_dlbus` so ESPHome detects the component

## Testing
- `esphome config example.yaml` *(fails: file removed)*
- `esphome config example.yaml` *(from earlier, config valid)*
- `esphome compile example.yaml` *(fails: network access for platformio)*

------
https://chatgpt.com/codex/tasks/task_e_6843ba879c948332a0e3d05b267eb16a