### PR TITLE
Fix shared UART buffer

### DIFF
--- a/components/uvr64_dlbus/sensor/uvr64_dlbus.cpp
+++ b/components/uvr64_dlbus/sensor/uvr64_dlbus.cpp
@@ -8,18 +8,16 @@ namespace uvr64_dlbus {
 static const char *const TAG = "uvr64_dlbus";
 
 void UVR64DLBusSensor::loop() {
-  static std::vector<uint8_t> buffer;
-
   while (this->available()) {
     uint8_t byte = this->read();
-    buffer.push_back(byte);
+    this->buffer_.push_back(byte);
 
-    if (buffer.size() >= 32) {
-      if (is_valid(buffer)) {
-        parse_dl_bus(buffer);
-        buffer.clear();
+    if (this->buffer_.size() >= 32) {
+      if (is_valid(this->buffer_)) {
+        parse_dl_bus(this->buffer_);
+        this->buffer_.clear();
       } else {
-        buffer.erase(buffer.begin());
+        this->buffer_.erase(this->buffer_.begin());
       }
     }
   }

--- a/components/uvr64_dlbus/sensor/uvr64_dlbus.h
+++ b/components/uvr64_dlbus/sensor/uvr64_dlbus.h
@@ -26,6 +26,8 @@ class UVR64DLBusSensor : public Component, public uart::UARTDevice {
   std::vector<sensor::Sensor *> temp_sensors;
   std::vector<sensor::Sensor *> relay_sensors;
 
+  std::vector<uint8_t> buffer_;
+
   void parse_dl_bus(const std::vector<uint8_t> &data);
   bool is_valid(const std::vector<uint8_t> &data);
 };


### PR DESCRIPTION
## Summary
- store DL-Bus bytes in a member variable instead of a static function variable

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843b8fe37048332bc2ddf71f0da50be