### PR TITLE
Add .gitignore for Python and ESPHome artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# C extensions
+*.so
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Virtual environments
+.venv/
+venv/
+ENV/
+env/
+
+# ESPHome build directories
+.esphome/
+.pioenvs/
+.piolibdeps/
+.pio/
+.pylibdeps/
+
+# PlatformIO build output
+.pio/build/
+
+# Misc
+*.log
+.DS_Store
+


### PR DESCRIPTION
## Summary
- ignore Python bytecode and temporary files
- ignore ESPHome and PlatformIO build output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843bf26567c833297892fa55d452bde