### PR TITLE
Add XOR decode option

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ external_components:
 sensor:
   - platform: uvr64_dlbus
     uart_id: dl_uart
+    decode_xor: true
     temperatures:
       - name: "UVR64 Temp 1"
       - name: "UVR64 Temp 2"

--- a/components/uvr64_dlbus/__init__.py
+++ b/components/uvr64_dlbus/__init__.py
@@ -1,6 +1,7 @@
 from .sensor.uvr64_dlbus import (
     CONF_TEMPERATURES,
     CONF_RELAYS,
+    CONF_DECODE_XOR,
     UVR64DLBusSensor,
     CONFIG_SCHEMA,
     to_code,

--- a/components/uvr64_dlbus/sensor/uvr64_dlbus.cpp
+++ b/components/uvr64_dlbus/sensor/uvr64_dlbus.cpp
@@ -10,6 +10,8 @@ static const char *const TAG = "uvr64_dlbus";
 void UVR64DLBusSensor::loop() {
   while (this->available()) {
     uint8_t byte = this->read();
+    if (this->decode_xor_)
+      byte ^= 0xFF;
     this->buffer_.push_back(byte);
 
     // Discard bytes until the expected start sequence is detected

--- a/components/uvr64_dlbus/sensor/uvr64_dlbus.h
+++ b/components/uvr64_dlbus/sensor/uvr64_dlbus.h
@@ -21,12 +21,15 @@ class UVR64DLBusSensor : public Component, public uart::UARTDevice {
 
   void set_temps(const std::vector<sensor::Sensor *> &sensors) { temp_sensors = sensors; }
   void set_relays(const std::vector<sensor::Sensor *> &sensors) { relay_sensors = sensors; }
+  void set_decode_xor(bool value) { decode_xor_ = value; }
 
  protected:
   std::vector<sensor::Sensor *> temp_sensors;
   std::vector<sensor::Sensor *> relay_sensors;
 
   std::vector<uint8_t> buffer_;
+
+  bool decode_xor_{false};
 
   static const uint8_t START_BYTE_1 = 0xAA;
   static const uint8_t START_BYTE_2 = 0x55;

--- a/components/uvr64_dlbus/sensor/uvr64_dlbus.py
+++ b/components/uvr64_dlbus/sensor/uvr64_dlbus.py
@@ -3,12 +3,16 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor, uart
 from esphome.const import (
-    CONF_ID, CONF_UART_ID, UNIT_CELSIUS,
-    DEVICE_CLASS_TEMPERATURE, ICON_THERMOMETER
+    CONF_ID,
+    CONF_UART_ID,
+    UNIT_CELSIUS,
+    DEVICE_CLASS_TEMPERATURE,
+    ICON_THERMOMETER,
 )
 
 CONF_TEMPERATURES = "temperatures"
 CONF_RELAYS = "relays"
+CONF_DECODE_XOR = "decode_xor"
 
 uvr64_ns = cg.esphome_ns.namespace("uvr64_dlbus")
 UVR64DLBusSensor = uvr64_ns.class_("UVR64DLBusSensor", cg.Component, uart.UARTDevice)
@@ -22,7 +26,8 @@ CONFIG_SCHEMA = cv.Schema({
         icon=ICON_THERMOMETER,
         device_class=DEVICE_CLASS_TEMPERATURE)),
     cv.Required(CONF_RELAYS): cv.ensure_list(sensor.sensor_schema(
-        accuracy_decimals=0))
+        accuracy_decimals=0)),
+    cv.Optional(CONF_DECODE_XOR, default=False): cv.boolean,
 }).extend(cv.COMPONENT_SCHEMA)
 
 async def to_code(config):
@@ -42,3 +47,5 @@ async def to_code(config):
         sens = await sensor.new_sensor(s)
         rels.append(sens)
     cg.add(var.set_relays(rels))
+
+    cg.add(var.set_decode_xor(config[CONF_DECODE_XOR]))


### PR DESCRIPTION
## Summary
- allow XOR decoding of DL-bus bytes
- make XOR decoding configurable with `decode_xor` parameter
- document the new option in README

## Testing
- `python -m py_compile components/uvr64_dlbus/sensor/uvr64_dlbus.py`

------
https://chatgpt.com/codex/tasks/task_e_6848fcf89d508332bf20dd9cfdf62e69