### PR TITLE
Fix to_code return in UVR64 DLBus component

### DIFF
--- a/components/uvr64_dlbus/sensor/uvr64_dlbus.py
+++ b/components/uvr64_dlbus/sensor/uvr64_dlbus.py
@@ -49,3 +49,5 @@ async def to_code(config):
     cg.add(var.set_relays(rels))
 
     cg.add(var.set_decode_xor(config[CONF_DECODE_XOR]))
+
+    return var


### PR DESCRIPTION
## Summary
- ensure `to_code` returns the created object

## Testing
- `python -m py_compile components/uvr64_dlbus/sensor/uvr64_dlbus.py`

------
https://chatgpt.com/codex/tasks/task_e_684900a5f42c83329ab8d9967c2b74f8