### PR TITLE
Remove unused esp_log include

### DIFF
--- a/components/uvr64_dlbus/sensor/uvr64_dlbus.cpp
+++ b/components/uvr64_dlbus/sensor/uvr64_dlbus.cpp
@@ -2,7 +2,6 @@
 #include "uvr64_dlbus.h"
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
-#include <esp_log.h>
 
 namespace esphome {
 namespace uvr64_dlbus {


### PR DESCRIPTION
## Summary
- drop esp_log include from UVR64 DL-Bus sensor

## Testing
- `esphome compile test.yaml` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68496c891d3c83328a1f122bc24c8146