### PR TITLE
Add example and parser unit test

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,3 +234,15 @@ sensor:
       - name: "UVR64 Relay 3"
       - name: "UVR64 Relay 4"
 ```
+
+
+See `examples/uvr64_example.yaml` for a complete example configuration.
+
+### Running the unit tests
+
+Install `pytest` and execute the tests from the repository root:
+
+```bash
+pip install pytest
+pytest
+```

--- a/components/uvr64_dlbus/parse_dl_bus.py
+++ b/components/uvr64_dlbus/parse_dl_bus.py
@@ -1,0 +1,27 @@
+"""Helper functions for testing the UVR64 parser."""
+
+from typing import List
+
+class DummySensor:
+    """Simple sensor placeholder used for unit tests."""
+
+    def __init__(self) -> None:
+        self.state = None
+
+    def publish_state(self, value) -> None:
+        self.state = value
+
+
+def parse_dl_bus(data: List[int], temp_sensors: List[DummySensor], relay_sensors: List[DummySensor]):
+    """Parse a raw DL-Bus frame and update sensors.
+
+    The function mimics the logic implemented in the C++ component.
+    """
+    for i, sens in enumerate(temp_sensors[:6]):
+        raw = (data[5 + i * 2] << 8) | data[6 + i * 2]
+        sens.publish_state(raw / 10.0)
+
+    if len(data) > 20:
+        status = data[20]
+        for i, sens in enumerate(relay_sensors[:8]):
+            sens.publish_state((status >> i) & 0x01)

--- a/examples/uvr64_example.yaml
+++ b/examples/uvr64_example.yaml
@@ -1,0 +1,29 @@
+# Example configuration for the UVR64 DL-Bus component
+
+uart:
+  id: dl_uart
+  rx_pin: RX
+  baud_rate: 2400
+
+external_components:
+  - source:
+      type: git
+      url: https://github.com/DerTolleMaz/esphome-uvr64
+    components: [uvr64_dlbus]
+
+sensor:
+  - platform: uvr64_dlbus
+    uart_id: dl_uart
+    decode_xor: true
+    temperatures:
+      - name: "UVR64 Temp 1"
+      - name: "UVR64 Temp 2"
+      - name: "UVR64 Temp 3"
+      - name: "UVR64 Temp 4"
+      - name: "UVR64 Temp 5"
+      - name: "UVR64 Temp 6"
+    relays:
+      - name: "UVR64 Relay 1"
+      - name: "UVR64 Relay 2"
+      - name: "UVR64 Relay 3"
+      - name: "UVR64 Relay 4"

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,0 +1,35 @@
+import pytest
+import importlib.util, os
+
+module_path = os.path.join(os.path.dirname(__file__), "..", "components", "uvr64_dlbus", "parse_dl_bus.py")
+spec = importlib.util.spec_from_file_location("parse_dl_bus", module_path)
+parse_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(parse_mod)
+parse_dl_bus = parse_mod.parse_dl_bus
+DummySensor = parse_mod.DummySensor
+# Example frame used for testing
+SAMPLE_FRAME = [
+    0xAA, 0x55, 0x00, 0x00, 0x00,
+    0x00, 0x64,  # 10.0°C
+    0x00, 0xC8,  # 20.0°C
+    0x01, 0x2C,  # 30.0°C
+    0x01, 0x90,  # 40.0°C
+    0x01, 0xF4,  # 50.0°C
+    0x02, 0x58,  # 60.0°C
+    0x00, 0x00, 0x00,
+    0x0D,        # relay status
+] + [0x00]*10
+
+# Add checksum
+checksum = sum(SAMPLE_FRAME) & 0xFF
+SAMPLE_FRAME.append(checksum)
+
+
+def test_parse_dl_bus():
+    temps = [DummySensor() for _ in range(6)]
+    relays = [DummySensor() for _ in range(4)]
+
+    parse_dl_bus(SAMPLE_FRAME, temps, relays)
+
+    assert [t.state for t in temps] == [10.0, 20.0, 30.0, 40.0, 50.0, 60.0]
+    assert [r.state for r in relays] == [1, 0, 1, 1]


### PR DESCRIPTION
## Summary
- add example config file showing full component usage
- implement Python helper for parsing frames and unit test
- document running the example and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68496f9d9b388332adb4ab7a47ade289