### PR TITLE
Add logger notes to README and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ DL-Bus GND -->| 2 (Cathode)      |       |           |
 
 ## Example ESPHome configuration
 
+Initialization messages from `UVR64DLBusSensor` are printed through ESPHome's
+`logger` component. Ensure this component is enabled so you can observe the
+sensor starting up.
+
 ```yaml
 uart:
   id: dl_uart
@@ -215,7 +219,9 @@ external_components:
       type: git
       url: https://github.com/DerTolleMaz/esphome-uvr64
     components: [uvr64_dlbus]
-
+logger:
+  level: DEBUG
+  baud_rate: 0
 
 sensor:
   - platform: uvr64_dlbus

--- a/examples/uvr64_example.yaml
+++ b/examples/uvr64_example.yaml
@@ -10,6 +10,9 @@ external_components:
       type: git
       url: https://github.com/DerTolleMaz/esphome-uvr64
     components: [uvr64_dlbus]
+logger:
+  level: DEBUG
+  baud_rate: 0
 
 sensor:
   - platform: uvr64_dlbus


### PR DESCRIPTION
## Summary
- mention the need for the logger component to display UVR64DLBusSensor startup
- show `logger:` section in README configuration snippet
- update the example YAML with the logger configuration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684973e7683c8332bcc62bb04be7a087