### PR TITLE
Ensure pycodestyle compliance

### DIFF
--- a/components/uvr64_dlbus/parse_dl_bus.py
+++ b/components/uvr64_dlbus/parse_dl_bus.py
@@ -2,6 +2,7 @@
 
 from typing import List
 
+
 class DummySensor:
     """Simple sensor placeholder used for unit tests."""
 
@@ -12,7 +13,11 @@ class DummySensor:
         self.state = value
 
 
-def parse_dl_bus(data: List[int], temp_sensors: List[DummySensor], relay_sensors: List[DummySensor]):
+def parse_dl_bus(
+    data: List[int],
+    temp_sensors: List[DummySensor],
+    relay_sensors: List[DummySensor],
+):
     """Parse a raw DL-Bus frame and update sensors.
 
     The function mimics the logic implemented in the C++ component.

--- a/components/uvr64_dlbus/sensor/uvr64_dlbus.py
+++ b/components/uvr64_dlbus/sensor/uvr64_dlbus.py
@@ -15,7 +15,11 @@ CONF_RELAYS = "relays"
 CONF_DECODE_XOR = "decode_xor"
 
 uvr64_ns = cg.esphome_ns.namespace("uvr64_dlbus")
-UVR64DLBusSensor = uvr64_ns.class_("UVR64DLBusSensor", cg.Component, uart.UARTDevice)
+UVR64DLBusSensor = uvr64_ns.class_(
+    "UVR64DLBusSensor",
+    cg.Component,
+    uart.UARTDevice,
+)
 
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(UVR64DLBusSensor),
@@ -29,6 +33,7 @@ CONFIG_SCHEMA = cv.Schema({
         accuracy_decimals=0)),
     cv.Optional(CONF_DECODE_XOR, default=False): cv.boolean,
 }).extend(cv.COMPONENT_SCHEMA)
+
 
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,7 +1,14 @@
 import pytest
-import importlib.util, os
+import importlib.util
+import os
 
-module_path = os.path.join(os.path.dirname(__file__), "..", "components", "uvr64_dlbus", "parse_dl_bus.py")
+module_path = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "components",
+    "uvr64_dlbus",
+    "parse_dl_bus.py",
+)
 spec = importlib.util.spec_from_file_location("parse_dl_bus", module_path)
 parse_mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(parse_mod)


### PR DESCRIPTION
## Summary
- fix spacing in parse helpers
- wrap long lines in parse helpers and sensor code
- format test helper for pycodestyle

## Testing
- `pycodestyle $(git ls-files '*.py') | head`

------
https://chatgpt.com/codex/tasks/task_e_6849759119c8833295e609d693cbe658