### PR TITLE
Handle new frames correctly

### DIFF
--- a/custom_components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/custom_components/uvr64_dlbus/dlbus_sensor.cpp
@@ -15,6 +15,9 @@ void DLBusSensor::setup() {
 void DLBusSensor::update() {
   if (frame_ready_) {
     parse_frame_();
+    bit_index_ = 0;
+    last_edge_ = micros();
+    attachInterruptArg(digitalPinToInterrupt(pin_), isr, this, CHANGE);
     frame_ready_ = false;
   }
 }


### PR DESCRIPTION
## Summary
- reset `bit_index_` after parsing a frame
- resume the interrupt handler to capture the next frame
- reinitialize timing from the current edge

## Testing
- `esphome --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a6779937483329b392c3b062d5cc6