### PR TITLE
Add UVR64 DLBus sensor platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ external_components:
       type: local
       path: ./custom_components
     components: [uvr64_dlbus]
+
+sensor:
+  - platform: uvr64_dlbus
+    pin: D1
+    temp_sensors:
+      - name: "Temp 1"
+      - name: "Temp 2"
+      - name: "Temp 3"
+      - name: "Temp 4"
+      - name: "Temp 5"
+      - name: "Temp 6"
+    relay_sensors:
+      - name: "Relais 1"
+      - name: "Relais 2"
+      - name: "Relais 3"
+      - name: "Relais 4"
 ```
 
 ## Lokaler Test

--- a/custom_components/uvr64_dlbus/__init__.py
+++ b/custom_components/uvr64_dlbus/__init__.py
@@ -1,1 +1,42 @@
-# Init for uvr64_dlbus component
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import pins
+from esphome.components import sensor, binary_sensor
+from esphome.const import CONF_PIN
+
+CONF_TEMP_SENSORS = "temp_sensors"
+CONF_RELAY_SENSORS = "relay_sensors"
+
+uvr64_dlbus_ns = cg.esphome_ns.namespace("uvr64_dlbus")
+DLBusSensor = uvr64_dlbus_ns.class_(
+    "DLBusSensor", sensor.Sensor, cg.PollingComponent
+)
+
+CONFIG_SCHEMA = (
+    sensor.sensor_schema(DLBusSensor)
+    .extend(
+        {
+            cv.Required(CONF_PIN): pins.internal_gpio_input_pin_number,
+            cv.Optional(CONF_TEMP_SENSORS, default=[]): cv.All(
+                cv.ensure_list(sensor.sensor_schema()), cv.Length(max=6)
+            ),
+            cv.Optional(CONF_RELAY_SENSORS, default=[]): cv.All(
+                cv.ensure_list(binary_sensor.binary_sensor_schema()), cv.Length(max=4)
+            ),
+        }
+    )
+    .extend(cv.polling_component_schema("60s"))
+)
+
+
+async def to_code(config):
+    var = await sensor.new_sensor(config, config[CONF_PIN])
+    await cg.register_component(var, config)
+
+    for i, conf in enumerate(config.get(CONF_TEMP_SENSORS, [])):
+        sens = await sensor.new_sensor(conf)
+        cg.add(var.set_temp_sensor(i, sens))
+
+    for i, conf in enumerate(config.get(CONF_RELAY_SENSORS, [])):
+        bs = await binary_sensor.new_binary_sensor(conf)
+        cg.add(var.set_relay_sensor(i, bs))

--- a/custom_components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/custom_components/uvr64_dlbus/dlbus_sensor.cpp
@@ -19,6 +19,16 @@ void DLBusSensor::update() {
   }
 }
 
+void DLBusSensor::set_temp_sensor(int index, sensor::Sensor *sensor) {
+  if (index >= 0 && index < 6)
+    temp_sensors_[index] = sensor;
+}
+
+void DLBusSensor::set_relay_sensor(int index, binary_sensor::BinarySensor *sensor) {
+  if (index >= 0 && index < 4)
+    relay_sensors_[index] = sensor;
+}
+
 void IRAM_ATTR DLBusSensor::isr(void *arg) {
   auto *self = static_cast<DLBusSensor *>(arg);
   unsigned long now = micros();

--- a/custom_components/uvr64_dlbus/dlbus_sensor.h
+++ b/custom_components/uvr64_dlbus/dlbus_sensor.h
@@ -7,7 +7,7 @@
 namespace esphome {
 namespace uvr64_dlbus {
 
-class DLBusSensor : public PollingComponent {
+class DLBusSensor : public sensor::Sensor, public PollingComponent {
  public:
   DLBusSensor(uint8_t pin) : pin_(pin) {}
   void setup() override;


### PR DESCRIPTION
## Summary
- implement configuration and codegen in `uvr64_dlbus` component
- expose setters for sensors and relays in C++
- document example YAML usage

## Testing
- `python -m py_compile custom_components/uvr64_dlbus/__init__.py`
- `esphome compile uvr64_dlbus.yaml` *(fails: Platform not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a677aac0c8332b1e74b0222906611