### PR TITLE
Fix UVR64 DL-Bus config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ external_components:
 
 sensor:
   - platform: uvr64_dlbus
+    id: uvr64_bus
     pin: D1
     temp_sensors:
       - name: "Temp 1"

--- a/uvr64_dlbus.yaml
+++ b/uvr64_dlbus.yaml
@@ -13,6 +13,7 @@ logger:
 
 sensor:
   - platform: uvr64_dlbus
+    id: uvr64_bus
     pin: D1
     temp_sensors:
       - name: "Temp 1"


### PR DESCRIPTION
## Summary
- add missing `id` to example config

## Testing
- `python -m py_compile components/uvr64_dlbus/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_684ab69de5d883328b1cff292cfa70d6