### PR TITLE
Add MIT license header to DLBus sensor sources

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/components/uvr64_dlbus/dlbus_sensor.cpp
@@ -1,3 +1,4 @@
+// MIT License - see LICENSE file in the project root for full details.
 #include "dlbus_sensor.h"
 #include "esphome/core/log.h"
 

--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -1,3 +1,4 @@
+// MIT License - see LICENSE file in the project root for full details.
 #pragma once
 
 #include "esphome/components/sensor/sensor.h"


### PR DESCRIPTION
## Summary
- mention MIT License at the top of DLBus sensor files

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684ab7bc60cc8332b849a334b7d68c58