### PR TITLE
Fix missing binary_sensor dependency

### DIFF
--- a/components/uvr64_dlbus/__init__.py
+++ b/components/uvr64_dlbus/__init__.py
@@ -1,1 +1,5 @@
 """Support for the UVR64 DL-Bus component."""
+
+# Automatically include ESPHome's binary_sensor component so that
+# ``binary_sensor.h`` is available during compilation.
+AUTO_LOAD = ["binary_sensor"]

--- a/uvr64_dlbus.yaml
+++ b/uvr64_dlbus.yaml
@@ -1,6 +1,7 @@
 esphome:
   name: uvr64_dlbus
-  platform: ESP8266
+
+esp8266:
   board: d1_mini
 
 external_components:


### PR DESCRIPTION
## Summary
- autoload binary_sensor component
- update example YAML for new ESPHome style

## Testing
- `pip install -r requirements.txt`
- `esphome compile uvr64_dlbus.yaml` *(fails: Tunnel connection failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_684ab98ceb8083328d9f0c5c55d34df4