### PR TITLE
Fix YAML config for ESPHome

### DIFF
--- a/uvr64_dlbus.yaml
+++ b/uvr64_dlbus.yaml
@@ -1,6 +1,6 @@
 esphome:
   name: uvr64_dlbus
-  platform: ESP8266
+esp8266:
   board: d1_mini
 
 external_components:


### PR DESCRIPTION
## Summary
- update the example YAML to the current ESPHome syntax

## Testing
- `esphome compile uvr64_dlbus.yaml` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_684b9a0192988332be609aecd21d5826