### PR TITLE
Fix compile errors by using local components

### DIFF
--- a/components/uvr64_dlbus/__init__.py
+++ b/components/uvr64_dlbus/__init__.py
@@ -1,2 +1,4 @@
 """Support for the UVR64 DL-Bus component."""
+
 AUTO_LOAD = ["binary_sensor"]
+DEPENDENCIES = ["binary_sensor"]

--- a/uvr64_dlbus.yaml
+++ b/uvr64_dlbus.yaml
@@ -5,12 +5,17 @@ esp8266:
 
 external_components:
   - source:
-      type: git
-      url: https://github.com/DerTolleMaz/esphome-uvr64
+      type: local
+      path: ./components
     components: [uvr64_dlbus]
-    refresh: always
 
 logger:
+
+binary_sensor:
+  - platform: template
+    name: "dummy"
+    lambda: |-
+      return false;
 
 sensor:
   - platform: uvr64_dlbus


### PR DESCRIPTION
## Summary
- use local path for uvr64_dlbus component
- ensure binary_sensor component is loaded

## Testing
- `esphome compile uvr64_dlbus.yaml`

------
https://chatgpt.com/codex/tasks/task_e_684b9b85ae8083328642345f3ec2e205