### PR TITLE
Add minimal parse_frame test

### DIFF
--- a/tests/stubs/arduino_stubs.h
+++ b/tests/stubs/arduino_stubs.h
@@ -1,0 +1,10 @@
+#pragma once
+extern "C" {
+static inline void pinMode(unsigned char, int) {}
+static inline unsigned long micros() { return 0; }
+static inline int digitalPinToInterrupt(int pin) { return pin; }
+static inline void attachInterruptArg(int, void (*)(void *), void *, int) {}
+static inline void detachInterrupt(int) {}
+}
+#define INPUT 0
+#define CHANGE 1

--- a/tests/stubs/esphome/components/binary_sensor/binary_sensor.h
+++ b/tests/stubs/esphome/components/binary_sensor/binary_sensor.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace binary_sensor {
+class BinarySensor {
+ public:
+  bool published_state = false;
+  void publish_state(bool state) { published_state = state; }
+};
+}  // namespace binary_sensor
+}  // namespace esphome

--- a/tests/stubs/esphome/components/sensor/sensor.h
+++ b/tests/stubs/esphome/components/sensor/sensor.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "esphome/core/component.h"
+
+namespace esphome {
+namespace sensor {
+class Sensor {
+ public:
+  float published_state = 0;
+  void publish_state(float state) { published_state = state; }
+};
+}  // namespace sensor
+}  // namespace esphome

--- a/tests/stubs/esphome/core/component.h
+++ b/tests/stubs/esphome/core/component.h
@@ -1,0 +1,24 @@
+#pragma once
+#include <cstdint>
+
+#ifndef IRAM_ATTR
+#define IRAM_ATTR
+#endif
+
+namespace esphome {
+class Component {
+ public:
+  virtual void setup() {}
+  virtual void loop() {}
+  virtual float get_setup_priority() const { return 0; }
+  virtual float get_loop_priority() const { return 0; }
+};
+
+class PollingComponent : public Component {
+ public:
+  explicit PollingComponent(uint32_t update_interval = 0) {}
+  virtual void set_update_interval(uint32_t) {}
+  virtual void update() {}
+  virtual uint32_t get_update_interval() const { return 0; }
+};
+}  // namespace esphome

--- a/tests/stubs/esphome/core/log.h
+++ b/tests/stubs/esphome/core/log.h
@@ -1,0 +1,9 @@
+#pragma once
+#define ESP_LOGD(tag, ...)
+#define ESP_LOGI(tag, ...)
+#define ESP_LOGCONFIG(tag, ...)
+#define ESP_LOGV(tag, ...)
+#define ESP_LOGE(tag, ...)
+#ifndef IRAM_ATTR
+#define IRAM_ATTR
+#endif

--- a/tests/test_parse_frame.cpp
+++ b/tests/test_parse_frame.cpp
@@ -1,0 +1,64 @@
+#include "arduino_stubs.h"
+#include "dlbus_sensor.h"
+#include <iostream>
+
+using namespace esphome::uvr64_dlbus;
+
+class TestDLBusSensor : public DLBusSensor {
+ public:
+  using DLBusSensor::DLBusSensor;
+  using DLBusSensor::parse_frame_;
+  using DLBusSensor::timings_;
+  using DLBusSensor::bit_index_;
+};
+
+
+static void encode_byte(TestDLBusSensor &sensor, uint8_t value) {
+  for (int i = 7; i >= 0; --i) {
+    bool bit = (value >> i) & 1;
+    sensor.timings_[sensor.bit_index_++] = bit ? 1 : 2;
+    sensor.timings_[sensor.bit_index_++] = bit ? 2 : 1;
+  }
+}
+
+int main() {
+  TestDLBusSensor sensor(0);
+
+  esphome::sensor::Sensor temps[6];
+  esphome::binary_sensor::BinarySensor relays[4];
+
+  for (int i = 0; i < 6; i++) sensor.set_temp_sensor(i, &temps[i]);
+  for (int i = 0; i < 4; i++) sensor.set_relay_sensor(i, &relays[i]);
+
+  uint8_t frame[8] = {0x00, 0xC8, 0x00, 0xD7, 0xFF, 0xF6, 0x01, 0x02};
+  sensor.bit_index_ = 0;
+  for (uint8_t b : frame) {
+    encode_byte(sensor, b);
+  }
+
+  sensor.parse_frame_();
+
+  float expected_temps[4] = {20.0f, 21.5f, -1.0f, 25.8f};
+  bool ok = true;
+  for (int i = 0; i < 4; i++) {
+    if (temps[i].published_state != expected_temps[i]) {
+      std::cerr << "Temp " << i << " mismatch: " << temps[i].published_state
+                << " != " << expected_temps[i] << std::endl;
+      ok = false;
+    }
+  }
+  for (int i = 0; i < 4; i++) {
+    if (relays[i].published_state != false) {
+      std::cerr << "Relay " << i << " expected false" << std::endl;
+      ok = false;
+    }
+  }
+
+  if (ok) {
+    std::cout << "parse_frame_() test passed" << std::endl;
+    return 0;
+  } else {
+    std::cerr << "parse_frame_() test failed" << std::endl;
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add stub ESPHome headers and Arduino mocks
- create `tests/test_parse_frame.cpp` to feed a fake frame to `DLBusSensor`

## Testing
- `g++ -std=c++17 -Icomponents/uvr64_dlbus -Itests/stubs -include tests/stubs/arduino_stubs.h tests/test_parse_frame.cpp components/uvr64_dlbus/dlbus_sensor.cpp -o tests/test_parse_frame && ./tests/test_parse_frame`


------
https://chatgpt.com/codex/tasks/task_e_684ba18860b88332a58714d5dac5545b