### PR TITLE
Guard tests with Arduino stubs

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/components/uvr64_dlbus/dlbus_sensor.cpp
@@ -1,6 +1,10 @@
 #include "dlbus_sensor.h"
 #include "esphome/core/log.h"
 
+#ifndef ARDUINO
+#include "arduino_stubs.h"
+#endif
+
 namespace esphome {
 namespace uvr64_dlbus {
 


### PR DESCRIPTION
## Summary
- guard the implementation so host builds include `arduino_stubs.h`

## Testing
- `g++ -I tests/stubs -I components/uvr64_dlbus -std=c++11 tests/test_parse_frame.cpp components/uvr64_dlbus/dlbus_sensor.cpp -o tests/test_parse_frame` *(fails: `timings_` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858d2420e5c83329fcbf0f6f743aa34