### PR TITLE
Add Makefile for tests and document requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ Nutze `source: local` und `path: ./components` in deiner YAML-Datei.
 Installiere ESPHome und führe `esphome compile uvr64_dlbus.yaml` aus.
 PlatformIO alleine löst Abhängigkeiten wie `binary_sensor.h` nicht auf.
 
+## Tests
+
+Zum Kompilieren der Beispieltests wird ein C++-Compiler (z.B. `g++`) und
+`make` benötigt. Der Test `test_parse_frame` im Verzeichnis `tests` kann mit
+
+```bash
+make -C tests
+```
+
+gebaut und mit
+
+```bash
+make -C tests run
+```
+
+ausgeführt werden.
+
 ## Lizenz
 
 Dieses Projekt steht unter der MIT-Lizenz – siehe die Datei [LICENSE](LICENSE) für Details.

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,18 @@
+CXX ?= g++
+CXXFLAGS := -std=c++11 -I../components/uvr64_dlbus -Istubs -Istubs/esphome -Istubs/esphome/components -Istubs/esphome/core
+
+all: test_parse_frame
+
+# Build the test executable
+
+test_parse_frame: test_parse_frame.cpp ../components/uvr64_dlbus/dlbus_sensor.cpp
+	$(CXX) $(CXXFLAGS) $^ -o $@
+
+# Run the test
+run: test_parse_frame
+	./test_parse_frame
+
+clean:
+	rm -f test_parse_frame
+
+.PHONY: all run clean


### PR DESCRIPTION
## Summary
- add `tests/Makefile` with targets to build and run the C++ test
- explain how to compile `test_parse_frame` and mention g++/make in README

## Testing
- `make test_parse_frame` *(fails: 'timings_' has not been declared)*

------
https://chatgpt.com/codex/tasks/task_e_6858d246c2048332845216e27676fc56