### PR TITLE
Implement Manchester decoding

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/components/uvr64_dlbus/dlbus_sensor.cpp
@@ -1,5 +1,6 @@
 #include "dlbus_sensor.h"
 #include "esphome/core/log.h"
+#include <cstring>
 
 namespace esphome {
 namespace uvr64_dlbus {
@@ -26,29 +27,70 @@ void DLBusSensor::loop() {
 
 void IRAM_ATTR DLBusSensor::isr(void *arg) {
   auto *self = static_cast<DLBusSensor *>(arg);
-  // TODO: Echtzeit-DL-Bus-Decoder hier implementieren.
-  self->frame_buffer_ready_ = true;
+  static uint32_t last = micros();
+  uint32_t now = micros();
+  uint16_t diff = now - last;
+  last = now;
+
+  if (self->bit_index_ < DLBusSensor::MAX_TIMINGS)
+    self->timings_[self->bit_index_++] = diff;
+
+  if (diff > 1000 && self->bit_index_ >= 16) {
+    self->frame_buffer_ready_ = true;
+  }
 }
 
 void DLBusSensor::parse_frame_() {
-  for (int i = 0; i < 6; i++) {
-    if (this->temp_sensors_[i]) {
-      this->temp_sensors_[i]->publish_state(20.0f + i);
+  const uint16_t bits = this->bit_index_ / 2;
+  uint8_t bytes[DLBusSensor::MAX_TIMINGS / 8]{};
+  uint8_t cur = 0;
+  uint16_t byte_index = 0;
+
+  for (uint16_t i = 0; i < bits; i++) {
+    bool bit = timings_[2 * i] < timings_[2 * i + 1];
+    cur = (cur << 1) | (bit ? 1 : 0);
+    if ((i % 8) == 7) {
+      bytes[byte_index++] = cur;
+      cur = 0;
     }
   }
-  for (int i = 0; i < 4; i++) {
-    if (this->relay_sensors_[i]) {
-      this->relay_sensors_[i]->publish_state(i % 2 == 0);
+
+  uint16_t temp_count = byte_index / 2;
+  if (temp_count > 6)
+    temp_count = 6;
+  for (uint16_t i = 0; i < temp_count; i++) {
+    int16_t raw = (int16_t)((bytes[i * 2] << 8) | bytes[i * 2 + 1]);
+    float value = raw / 10.0f;
+    if (this->temp_sensors_[i])
+      this->temp_sensors_[i]->publish_state(value);
+  }
+
+  if (byte_index > 8) {
+    uint8_t relay = bytes[8];
+    for (int i = 0; i < 4; i++) {
+      if (this->relay_sensors_[i])
+        this->relay_sensors_[i]->publish_state(relay & (1 << i));
+    }
+  } else {
+    for (int i = 0; i < 4; i++) {
+      if (this->relay_sensors_[i]) this->relay_sensors_[i]->publish_state(false);
     }
   }
-  ESP_LOGD(TAG, "Parsed DLBus frame (dummy values).");
+  ESP_LOGD(TAG, "Parsed DLBus frame with %d bytes", byte_index);
+  bit_index_ = 0;
 }
 
 void DLBusSensor::compute_timing_stats_() {
-  ESP_LOGI(TAG, "Bit length histogram:");
+  memset(timing_histogram_, 0, sizeof(timing_histogram_));
+  for (uint16_t i = 0; i < bit_index_; i++) {
+    uint16_t val = timings_[i];
+    if (val >= 64) val = 63;
+    timing_histogram_[val]++;
+  }
+  ESP_LOGD(TAG, "Bit length histogram:");
   for (int i = 0; i < 64; i++) {
     if (timing_histogram_[i] > 0) {
-      ESP_LOGI(TAG, "  Length %d: %d samples", i, timing_histogram_[i]);
+      ESP_LOGD(TAG, "  Length %d: %d samples", i, timing_histogram_[i]);
     }
   }
 }

--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -29,6 +29,9 @@ class DLBusSensor : public Component {
   uint8_t pin_;
   sensor::Sensor *temp_sensors_[6]{};
   binary_sensor::BinarySensor *relay_sensors_[4]{};
+  static const uint16_t MAX_TIMINGS = 256;
+  volatile uint16_t timings_[MAX_TIMINGS]{};
+  volatile uint16_t bit_index_ = 0;
   volatile bool frame_buffer_ready_ = false;
   uint16_t timing_histogram_[64]{};
 };


### PR DESCRIPTION
## Summary
- implement Manchester decoder and fill sensor states
- collect bit timing histogram
- expose timing buffer for tests

## Testing
- `g++ -std=c++17 tests/test_parse_frame.cpp components/uvr64_dlbus/dlbus_sensor.cpp -include tests/stubs/arduino_stubs.h -Itests/stubs -Icomponents/uvr64_dlbus -o tests/test_parse_frame && ./tests/test_parse_frame`

------
https://chatgpt.com/codex/tasks/task_e_6858d2440350833294cca9b9a20d9764