### PR TITLE
Fix compile error by adding default constructor

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/components/uvr64_dlbus/dlbus_sensor.cpp
@@ -14,6 +14,11 @@ namespace uvr64_dlbus {
 
 static const char *const TAG = "uvr64_dlbus";
 
+DLBusSensor::DLBusSensor() : pin_(0) {
+  this->bit_index_ = 0;
+  this->timings_.fill(0);
+}
+
 DLBusSensor::DLBusSensor(uint8_t pin) : pin_(pin) {
   this->bit_index_ = 0;
   this->timings_.fill(0);

--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -11,7 +11,9 @@ namespace uvr64_dlbus {
 
 class DLBusSensor : public Component {
  public:
+  DLBusSensor();
   explicit DLBusSensor(uint8_t pin);
+  void set_pin(uint8_t pin) { this->pin_ = pin; }
   void setup() override;
   void loop() override;
 


### PR DESCRIPTION
## Summary
- add a default constructor to `DLBusSensor`
- provide a simple `set_pin()` method for runtime configuration

This resolves compilation issues when the component is instantiated with no arguments.

## Testing
- `make -C tests clean all`
- `./test_parse_frame`


------
https://chatgpt.com/codex/tasks/task_e_6858d51df1fc8332a8c315b8bdce4040