### PR TITLE
Fix attach_interrupt usage in DLBusSensor

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -29,7 +29,7 @@ class DLBusSensor : public Component {
   }
 
  protected:
-  static void IRAM_ATTR isr(void *arg);
+  static void IRAM_ATTR isr(DLBusSensor *arg);
   void parse_frame_();
   void compute_timing_stats_();
 

--- a/tests/stubs/esphome/core/gpio.h
+++ b/tests/stubs/esphome/core/gpio.h
@@ -30,6 +30,10 @@ class InternalGPIOPin {
   virtual bool digital_read() { return false; }
   virtual void digital_write(bool) {}
   virtual ISRInternalGPIOPin to_isr() const { return ISRInternalGPIOPin(); }
+  template<typename T>
+  void attach_interrupt(void (*func)(T *), T *arg, gpio::InterruptType type) const {
+    this->attach_interrupt(reinterpret_cast<void (*)(void *)>(func), arg, type);
+  }
   virtual void attach_interrupt(void (*)(void *), void *, gpio::InterruptType) const {}
   virtual void detach_interrupt() const {}
   virtual uint8_t get_pin() const { return 0; }


### PR DESCRIPTION
## Summary
- update ISR signature to use `DLBusSensor*`
- call `attach_interrupt` via the public template overload
- cast when calling Arduino's `attachInterruptArg`
- update GPIO stub with matching template overload

## Testing
- `make -C tests`
- `make -C tests run`

------
https://chatgpt.com/codex/tasks/task_e_6858e00283d08332b829655d44fd7c80