### PR TITLE
Fix lambda references and ensure compile success

### DIFF
--- a/uvr64_dlbus.yaml
+++ b/uvr64_dlbus.yaml
@@ -1,5 +1,9 @@
 esphome:
   name: uvr64_dlbus
+  includes:
+    - components/uvr64_dlbus/dlbus_sensor.h
+    - <dlbus_sensor.h>
+    - components/uvr64_dlbus/dlbus_sensor.cpp
 esp8266:
   board: d1_mini
 
@@ -65,17 +69,17 @@ interval:
     then:
       - lambda: |-
           if (id(dlbus_ptr) == nullptr) {
-            auto dl = new esphome::uvr64_dlbus::DLBusSensor(GPIO_NUM_4);
-            dl->set_temp_sensor(0, &id(temp0));
-            dl->set_temp_sensor(1, &id(temp1));
-            dl->set_temp_sensor(2, &id(temp2));
-            dl->set_temp_sensor(3, &id(temp3));
-            dl->set_temp_sensor(4, &id(temp4));
-            dl->set_temp_sensor(5, &id(temp5));
-            dl->set_relay_sensor(0, &id(relay0));
-            dl->set_relay_sensor(1, &id(relay1));
-            dl->set_relay_sensor(2, &id(relay2));
-            dl->set_relay_sensor(3, &id(relay3));
+            auto dl = new esphome::uvr64_dlbus::DLBusSensor(4);
+            dl->set_temp_sensor(0, id(temp0));
+            dl->set_temp_sensor(1, id(temp1));
+            dl->set_temp_sensor(2, id(temp2));
+            dl->set_temp_sensor(3, id(temp3));
+            dl->set_temp_sensor(4, id(temp4));
+            dl->set_temp_sensor(5, id(temp5));
+            dl->set_relay_sensor(0, id(relay0));
+            dl->set_relay_sensor(1, id(relay1));
+            dl->set_relay_sensor(2, id(relay2));
+            dl->set_relay_sensor(3, id(relay3));
             id(dlbus_ptr) = dl;
             App.register_component(dl);
           }


### PR DESCRIPTION
## Summary
- remove pointer indirection from lambda sensor references
- include component headers and source for successful build
- adjust pin constant for ESP8266 board

## Testing
- `esphome compile uvr64_dlbus.yaml`

------
https://chatgpt.com/codex/tasks/task_e_685a2792293c83328e007ce711811dec