### PR TITLE
Update DLBus pin handling

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/components/uvr64_dlbus/dlbus_sensor.cpp
@@ -29,6 +29,13 @@ DLBusSensor::DLBusSensor(InternalGPIOPin *pin) : pin_(pin) {
   this->timings_.fill(0);
 }
 
+uint8_t DLBusSensor::get_pin() const {
+  if (this->pin_ != nullptr) {
+    return this->pin_->get_pin();
+  }
+  return this->pin_num_;
+}
+
 void DLBusSensor::setup() {
   if (this->pin_ != nullptr) {
     this->pin_->setup();

--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -17,6 +17,7 @@ class DLBusSensor : public Component {
   explicit DLBusSensor(InternalGPIOPin *pin);
   void set_pin(uint8_t pin) { this->pin_num_ = pin; }
   void set_pin(InternalGPIOPin *pin) { this->pin_ = pin; }
+  uint8_t get_pin() const;
   void setup() override;
   void loop() override;
 

--- a/uvr64_dlbus.yaml
+++ b/uvr64_dlbus.yaml
@@ -49,6 +49,22 @@ sensor:
     id: temp5
     unit_of_measurement: "°C"
 
+  - platform: uvr64_dlbus
+    id: uvr
+    pin: D2
+    temp_sensors:
+      - id(temp0)
+      - id(temp1)
+      - id(temp2)
+      - id(temp3)
+      - id(temp4)
+      - id(temp5)
+    relay_sensors:
+      - id(relay0)
+      - id(relay1)
+      - id(relay2)
+      - id(relay3)
+
 binary_sensor:
   - platform: template
     name: "UVR64 Relay Boiler"
@@ -69,7 +85,7 @@ interval:
     then:
       - lambda: |-
           if (id(dlbus_ptr) == nullptr) {
-            auto dl = new esphome::uvr64_dlbus::DLBusSensor(4);
+            auto dl = new esphome::uvr64_dlbus::DLBusSensor(id(uvr)->get_pin());
             dl->set_temp_sensor(0, id(temp0));
             dl->set_temp_sensor(1, id(temp1));
             dl->set_temp_sensor(2, id(temp2));


### PR DESCRIPTION
## Summary
- allow retrieving the configured GPIO pin from `DLBusSensor`
- connect dynamic DL-Bus creation to the pin provided by `id(uvr)`
- add `uvr64_dlbus` sensor block showing pin configuration

## Testing
- `make -C tests`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_685a2a5fe4ec83329f19d9f4122e837f