### PR TITLE
Support full microsecond timings

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/components/uvr64_dlbus/dlbus_sensor.cpp
@@ -83,7 +83,7 @@ void IRAM_ATTR DLBusSensor::isr(DLBusSensor *arg) {
   uint32_t delta = now - self->last_change_;
   self->last_change_ = now;
   if (self->bit_index_ < DLBusSensor::MAX_BITS) {
-    self->timings_[self->bit_index_++] = static_cast<uint8_t>(std::min(delta, 255u));
+    self->timings_[self->bit_index_++] = static_cast<uint16_t>(delta);
     if (self->bit_index_ >= DLBusSensor::MAX_BITS) {
       self->frame_buffer_ready_ = true;
     }

--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -37,8 +37,8 @@ class DLBusSensor : public Component {
   uint8_t pin_num_{0};
   InternalGPIOPin *pin_{nullptr};
   ISRInternalGPIOPin pin_isr_;
-  static constexpr size_t MAX_BITS = 128;
-  std::array<uint8_t, MAX_BITS> timings_{};
+  static constexpr size_t MAX_BITS = 256;
+  std::array<uint16_t, MAX_BITS> timings_{};
   size_t bit_index_ = 0;
   sensor::Sensor *temp_sensors_[6]{};
   binary_sensor::BinarySensor *relay_sensors_[4]{};

--- a/tests/test_parse_frame.cpp
+++ b/tests/test_parse_frame.cpp
@@ -13,11 +13,14 @@ class TestDLBusSensor : public DLBusSensor {
 };
 
 
+static const uint16_t SHORT_US = 300;
+static const uint16_t LONG_US = 600;
+
 static void encode_byte(TestDLBusSensor &sensor, uint8_t value) {
   for (int i = 7; i >= 0; --i) {
     bool bit = (value >> i) & 1;
-    sensor.timings_[sensor.bit_index_++] = bit ? 1 : 2;
-    sensor.timings_[sensor.bit_index_++] = bit ? 2 : 1;
+    sensor.timings_[sensor.bit_index_++] = bit ? SHORT_US : LONG_US;
+    sensor.timings_[sensor.bit_index_++] = bit ? LONG_US : SHORT_US;
   }
 }
 


### PR DESCRIPTION
## Summary
- store timing intervals as 16-bit values
- bump MAX_BITS to 256
- allow ISR to record >255µs intervals
- adjust test to use realistic 300/600µs timings

## Testing
- `make -C tests clean && make -C tests && ./tests/test_parse_frame`

------
https://chatgpt.com/codex/tasks/task_e_685a4df55a0c83328d9e72430e7c5cd3