### PR TITLE
Add UVR64 bus hardware notes

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -45,8 +45,17 @@ sensor:
       - name: "Relay 1"
       - name: "Relay 2"
       - name: "Relay 3"
-      - name: "Relay 4"
+  - name: "Relay 4"
 ```
+
+## Hardware
+
+The UVR64 DL bus is a 24 V open‑drain line. It needs a pull‑up resistor to 24 V
+and must be level shifted for a 3.3 V microcontroller such as the ESP8266. One
+simple circuit uses an NPN transistor with a pull‑up to 3.3 V on the collector
+and a voltage divider on the bus side (e.g. 22 kΩ/4.7 kΩ). The UVR64
+specification states a bit frequency of 50 Hz, so each bit lasts 20 ms and edge
+timing is critical.
 
 ### Local test
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ sensor:
       - name: "Relais 4"
 ```
 
+## Hardware
+
+Der DL-Bus des UVR64 arbeitet offen kollektor mit 24 V. Die Leitung muss über
+einen Pull‑Up‑Widerstand auf 24 V gehalten werden. Zum Anschluss an den
+3,3‑V‑Eingang eines ESP8266 ist daher eine Pegelanpassung nötig. Ein möglicher
+Aufbau besteht aus einem NPN-Transistor mit Pull‑Up auf 3,3 V und einem
+Spannungsteiler (z. B. 22 kΩ/4,7 kΩ) am Bus. Laut Spezifikation beträgt die
+Bitfrequenz 50 Hz, also 20 ms pro Bit, sodass die Flanken präzise erfasst werden
+müssen.
+
 ## Lokaler Test
 
 Nutze `source: local` und `path: ./components` in deiner YAML-Datei.


### PR DESCRIPTION
## Summary
- document bus wiring for the UVR64 DL bus
- explain the 24 V pull-up and level shifting
- reference the 50 Hz timing from the spec

## Testing
- `make -C tests`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_685a4dfd67508332a66691a3a82253fa