### PR TITLE
Add 6 temperature sensors and relay decoding

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -37,7 +37,7 @@ class DLBusSensor : public Component {
   uint8_t pin_num_{0};
   InternalGPIOPin *pin_{nullptr};
   ISRInternalGPIOPin pin_isr_;
-  static constexpr size_t MAX_BITS = 128;
+  static constexpr size_t MAX_BITS = 256;
   std::array<uint8_t, MAX_BITS> timings_{};
   size_t bit_index_ = 0;
   sensor::Sensor *temp_sensors_[6]{};

--- a/tests/test_parse_frame.cpp
+++ b/tests/test_parse_frame.cpp
@@ -30,7 +30,18 @@ int main() {
   for (int i = 0; i < 6; i++) sensor.set_temp_sensor(i, &temps[i]);
   for (int i = 0; i < 4; i++) sensor.set_relay_sensor(i, &relays[i]);
 
-  uint8_t frame[8] = {0x00, 0xC8, 0x00, 0xD7, 0xFF, 0xF6, 0x01, 0x02};
+  uint8_t frame[16] = {
+      0x00, 0xC8,  // 20.0°C
+      0x00, 0xD7,  // 21.5°C
+      0xFF, 0xF6,  // -1.0°C
+      0x01, 0x02,  // 25.8°C
+      0x00, 0xFA,  // 25.0°C
+      0xFF, 0xE6,  // -2.6°C
+      0x01,        // Relay 0 on
+      0x00,        // Relay 1 off
+      0x01,        // Relay 2 on
+      0x00         // Relay 3 off
+  };
   sensor.bit_index_ = 0;
   for (uint8_t b : frame) {
     encode_byte(sensor, b);
@@ -38,18 +49,20 @@ int main() {
 
   sensor.parse_frame_();
 
-  float expected_temps[4] = {20.0f, 21.5f, -1.0f, 25.8f};
+  float expected_temps[6] = {20.0f, 21.5f, -1.0f, 25.8f, 25.0f, -2.6f};
   bool ok = true;
-  for (int i = 0; i < 4; i++) {
+  for (int i = 0; i < 6; i++) {
     if (temps[i].published_state != expected_temps[i]) {
       std::cerr << "Temp " << i << " mismatch: " << temps[i].published_state
                 << " != " << expected_temps[i] << std::endl;
       ok = false;
     }
   }
+  bool expected_relays[4] = {true, false, true, false};
   for (int i = 0; i < 4; i++) {
-    if (relays[i].published_state != false) {
-      std::cerr << "Relay " << i << " expected false" << std::endl;
+    if (relays[i].published_state != expected_relays[i]) {
+      std::cerr << "Relay " << i << " mismatch: " << relays[i].published_state
+                << " != " << expected_relays[i] << std::endl;
       ok = false;
     }
   }


### PR DESCRIPTION
## Summary
- support frames with six temperature sensors and four relay states
- parse relay states from bytes instead of publishing `false`
- expand MAX_BITS to accommodate larger frames
- test parsing of all six temperatures and relay states

## Testing
- `make -C tests run`

------
https://chatgpt.com/codex/tasks/task_e_6861360cc19083329ce20ac0f1cd8755