### PR TITLE
Log partial DLBus signals

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/components/uvr64_dlbus/dlbus_sensor.cpp
@@ -74,6 +74,23 @@ void DLBusSensor::loop() {
     bit_index_ = 0;
     timings_.fill(0);
     levels_.fill(0);
+  } else if (bit_index_ > 0) {
+    ESP_LOGD(TAG, "Incomplete frame with %d bits", bit_index_);
+    if (this->pin_ != nullptr) {
+      this->pin_->detach_interrupt();
+    } else {
+      detachInterrupt(digitalPinToInterrupt(pin_num_));
+    }
+    dump_signal_();
+    if (this->pin_ != nullptr) {
+      this->pin_->attach_interrupt(&DLBusSensor::isr, this, gpio::INTERRUPT_ANY_EDGE);
+    } else {
+      attachInterruptArg(digitalPinToInterrupt(pin_num_),
+                        reinterpret_cast<void (*)(void *)>(&DLBusSensor::isr), this, CHANGE);
+    }
+    bit_index_ = 0;
+    timings_.fill(0);
+    levels_.fill(0);
   }
 }
 


### PR DESCRIPTION
## Summary
- allow `DLBusSensor` to dump the captured buffer even when a full frame wasn't read
- make debugging easier because partial frames are now logged

## Testing
- `cd tests && make clean && make && make run`

------
https://chatgpt.com/codex/tasks/task_e_686138be7f288332988952db4d698492