### PR TITLE
Add frame timeout to finish DLBus frames

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -37,6 +37,7 @@ class DLBusSensor : public Component {
   uint8_t pin_num_{0};
   InternalGPIOPin *pin_{nullptr};
   ISRInternalGPIOPin pin_isr_;
+  static constexpr uint32_t FRAME_TIMEOUT_US = 5000;
   static constexpr size_t MAX_BITS = 256;
   std::array<uint8_t, MAX_BITS> timings_{};
   std::array<uint8_t, MAX_BITS> levels_{};


### PR DESCRIPTION
## Summary
- detect end-of-frame by checking time since last signal edge
- log and process frames once input is idle

## Testing
- `make -C tests`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_68613c289aa88332a48e3747b447cfc9