### PR TITLE
Fix decoder and stub includes

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -5,6 +5,7 @@
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
 #include <array>
+#include <cstddef>
 
 namespace esphome {
 namespace uvr64_dlbus {

--- a/tests/stubs/esphome/core/log.h
+++ b/tests/stubs/esphome/core/log.h
@@ -1,6 +1,7 @@
 #pragma once
 #define ESP_LOGD(tag, ...)
 #define ESP_LOGI(tag, ...)
+#define ESP_LOGW(tag, ...)
 #define ESP_LOGCONFIG(tag, ...)
 #define ESP_LOGV(tag, ...)
 #define ESP_LOGE(tag, ...)


### PR DESCRIPTION
## Summary
- add missing warning log stub
- include `<cstddef>` in header and ensure `Arduino.h` is optional
- simplify `parse_frame_` to work with raw temperature/relay data
- tests pass

## Testing
- `make -C tests clean`
- `make -C tests`
- `make -C tests run`

------
https://chatgpt.com/codex/tasks/task_e_686214fe92bc83328bf83824fb008174