### PR TITLE
Implement DL bus decoder

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -8,12 +8,14 @@
 
 #include <array>
 #include <vector>
+#include <cstddef>
 
 namespace esphome {
 namespace uvr64_dlbus {
 
 static const uint32_t FRAME_TIMEOUT_US = 40000;  // 40 ms Frame-Timeout
 static const size_t MAX_BITS = 1024;              // Buffer size
+static const uint32_t HALF_BIT_US = 10000;        // 10 ms half bit
 
 class DLBusSensor : public Component {
  public:
@@ -34,8 +36,6 @@ class DLBusSensor : public Component {
   static void IRAM_ATTR isr(DLBusSensor *arg);
 
   void parse_frame_();
-  bool decode_manchester_(std::vector<bool> &bits, std::vector<uint8_t> &bytes);
-  bool find_sync_(const std::vector<bool> &bits, size_t &sync_pos);
   void log_bits_();
   void log_frame_(const std::vector<uint8_t> &frame);
 

--- a/tests/stubs/esphome/core/helpers.h
+++ b/tests/stubs/esphome/core/helpers.h
@@ -1,0 +1,5 @@
+#pragma once
+// Minimal helpers stub for tests
+
+#define IRAM_ATTR
+


### PR DESCRIPTION
## Summary
- add minimal `helpers.h` stub
- implement Manchester decoding and parse logic for DL bus frames
- include Arduino compatibility headers
- adjust bit logging to show captured timing units

## Testing
- `make -C tests`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_68628df2c8208332b8fcd959e35d3c4f