### PR TITLE
Fix compile errors and add parse_frame wrapper

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/components/uvr64_dlbus/dlbus_sensor.cpp
@@ -1,6 +1,15 @@
 #include "dlbus_sensor.h"
 #include "esphome/core/log.h"
+#ifdef ARDUINO
 #include <Arduino.h>
+#else
+#include "arduino_stubs.h"
+#endif
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
 
 namespace esphome {
 namespace uvr64_dlbus {
@@ -71,6 +80,17 @@ void DLBusSensor::process_frame_() {
 
   log_frame_(decoded_bytes);
   parse_frame_(decoded_bytes);
+}
+
+void DLBusSensor::parse_frame_() {
+  std::vector<uint8_t> decoded;
+  if (!decode_manchester_(decoded)) {
+    ESP_LOGW(TAG, "Manchester decode failed");
+    log_bits_();
+    return;
+  }
+  log_frame_(decoded);
+  parse_frame_(decoded);
 }
 
 bool DLBusSensor::decode_manchester_(std::vector<uint8_t> &result) {

--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -3,9 +3,13 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#include <vector>
 
 namespace esphome {
 namespace uvr64_dlbus {
+
+static const uint32_t FRAME_TIMEOUT_US = 100000;  // 100ms
+static const int MAX_BITS = 1024;
 
 class DLBusSensor : public Component {
  public:
@@ -23,6 +27,7 @@ class DLBusSensor : public Component {
  protected:
   void process_frame_();
   void parse_frame_(const std::vector<uint8_t> &frame);
+  void parse_frame_();
   void log_frame_(const std::vector<uint8_t> &frame);
   bool decode_manchester_(std::vector<uint8_t> &result);
   void log_bits_();
@@ -33,7 +38,6 @@ class DLBusSensor : public Component {
   uint32_t last_change_{0};
   bool frame_buffer_ready_{false};
 
-  static const int MAX_BITS = 1024;
   uint8_t levels_[MAX_BITS];
   uint8_t timings_[MAX_BITS];
   uint16_t bit_index_{0};


### PR DESCRIPTION
## Summary
- add missing includes and constants
- provide parse_frame_() wrapper for tests
- guard Arduino includes for host build

## Testing
- `make -C tests clean && make -C tests && ./tests/test_parse_frame`

------
https://chatgpt.com/codex/tasks/task_e_68638b6f36d883329b0846e26dc7b9da