### PR TITLE
Fix DLBusSensor constructor and pin handling

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -3,6 +3,7 @@
 #include "esphome/core/component.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/components/binary_sensor/binary_sensor.h"
+#include "esphome/core/gpio.h"
 #include <vector>
 
 namespace esphome {
@@ -13,10 +14,11 @@ static const int MAX_BITS = 1024;
 
 class DLBusSensor : public Component {
  public:
-  DLBusSensor(uint8_t pin) : pin_num_(pin) {}
+  explicit DLBusSensor(InternalGPIOPin *pin) : pin_(pin) {}
 
-  void set_pin(uint8_t pin) { this->pin_num_ = pin; }
-  uint8_t get_pin() const { return pin_num_; }
+  void set_pin(InternalGPIOPin *pin) { this->pin_ = pin; }
+  InternalGPIOPin *get_pin() const { return pin_; }
+  uint8_t get_pin_num() const { return pin_ ? pin_->get_pin() : 0; }
 
   void set_temp_sensor(uint8_t index, sensor::Sensor *sensor) { temp_sensors_[index] = sensor; }
   void set_relay_sensor(uint8_t index, binary_sensor::BinarySensor *sensor) { relay_sensors_[index] = sensor; }
@@ -34,7 +36,7 @@ class DLBusSensor : public Component {
 
   static void IRAM_ATTR gpio_isr_(DLBusSensor *arg);
 
-  uint8_t pin_num_;
+  InternalGPIOPin *pin_;
   uint32_t last_change_{0};
   bool frame_buffer_ready_{false};
 

--- a/tests/test_parse_frame.cpp
+++ b/tests/test_parse_frame.cpp
@@ -12,6 +12,16 @@ class TestDLBusSensor : public DLBusSensor {
   using DLBusSensor::bit_index_;
 };
 
+class DummyPin : public esphome::InternalGPIOPin {
+ public:
+  explicit DummyPin(uint8_t pin) : pin_(pin) {}
+  uint8_t get_pin() const override { return pin_; }
+  void setup() override {}
+  void pin_mode(esphome::gpio::Flags) override {}
+ private:
+  uint8_t pin_;
+};
+
 
 static void encode_byte(TestDLBusSensor &sensor, uint8_t value) {
   for (int i = 7; i >= 0; --i) {
@@ -22,7 +32,8 @@ static void encode_byte(TestDLBusSensor &sensor, uint8_t value) {
 }
 
 int main() {
-  TestDLBusSensor sensor(static_cast<uint8_t>(0));
+  DummyPin pin(0);
+  TestDLBusSensor sensor(&pin);
 
   esphome::sensor::Sensor temps[6];
   esphome::binary_sensor::BinarySensor relays[4];


### PR DESCRIPTION
## Summary
- store GPIO pin using `InternalGPIOPin*` instead of raw number
- update interrupt logic to use InternalGPIOPin methods
- adjust unit test for new constructor

## Testing
- `make -C tests`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_68638ceabfec83329a915b0127a977cf