### PR TITLE
Fix DLBusSensor constructor usage

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.py
+++ b/components/uvr64_dlbus/dlbus_sensor.py
@@ -18,10 +18,10 @@ CONFIG_SCHEMA = cv.Schema({
 }).extend(cv.COMPONENT_SCHEMA)
 
 async def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+    pin = await cg.gpio_pin_expression(config[CONF_PIN])
+    var = cg.new_Pvariable(config[CONF_ID], pin)
     await cg.register_component(var, config)
 
-    pin = await cg.gpio_pin_expression(config[CONF_PIN])
     cg.add(var.set_pin(pin))
 
     for i, sens in enumerate(config[CONF_TEMP_SENSORS]):


### PR DESCRIPTION
## Summary
- pass pin argument when creating `DLBusSensor`

## Testing
- `make -C tests run`
- `esphome compile uvr64_dlbus_local.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68638f80c7e483329974cb47328c117b