### PR TITLE
Update DLBus timing to 16-bit

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/components/uvr64_dlbus/dlbus_sensor.cpp
@@ -61,12 +61,13 @@ void DLBusSensor::loop() {
 void IRAM_ATTR DLBusSensor::gpio_isr_(DLBusSensor *sensor) {
   uint32_t now = micros();
   bool level = sensor->pin_->digital_read();
-  uint32_t duration = now - sensor->last_change_;
+  uint32_t diff = now - sensor->last_change_;
+  uint16_t duration = diff > UINT16_MAX ? UINT16_MAX : static_cast<uint16_t>(diff);
   sensor->last_change_ = now;
 
   if (sensor->bit_index_ < MAX_BITS) {
     sensor->levels_[sensor->bit_index_] = level;
-    sensor->timings_[sensor->bit_index_] = (duration > 255) ? 255 : duration;
+    sensor->timings_[sensor->bit_index_] = duration;
     sensor->bit_index_++;
   }
 }

--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -41,7 +41,7 @@ class DLBusSensor : public Component {
   bool frame_buffer_ready_{false};
 
   uint8_t levels_[MAX_BITS];
-  uint8_t timings_[MAX_BITS];
+  uint16_t timings_[MAX_BITS];
   uint16_t bit_index_{0};
 
   sensor::Sensor *temp_sensors_[6]{};


### PR DESCRIPTION
## Summary
- widen DLBus timing buffer to `uint16_t`
- clamp ISR duration to `UINT16_MAX`
- run unit tests

## Testing
- `make -C tests`
- `make -C tests run`

------
https://chatgpt.com/codex/tasks/task_e_6863a47cc4248332b578766d23cb11dd