### PR TITLE
Improve DL-Bus decoder

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -20,6 +20,9 @@ class DLBusSensor : public Component {
   InternalGPIOPin *get_pin() const { return pin_; }
   uint8_t get_pin_num() const { return pin_ ? pin_->get_pin() : 0; }
 
+  void set_debug(bool enable) { debug_ = enable; }
+  bool is_debug() const { return debug_; }
+
   void set_temp_sensor(uint8_t index, sensor::Sensor *sensor) { temp_sensors_[index] = sensor; }
   void set_relay_sensor(uint8_t index, binary_sensor::BinarySensor *sensor) { relay_sensors_[index] = sensor; }
 
@@ -33,6 +36,7 @@ class DLBusSensor : public Component {
   void log_frame_(const std::vector<uint8_t> &frame);
   bool decode_manchester_(std::vector<uint8_t> &result);
   void log_bits_();
+  bool validate_frame_(const std::vector<uint8_t> &frame);
 
   static void IRAM_ATTR gpio_isr_(DLBusSensor *arg);
 
@@ -43,6 +47,8 @@ class DLBusSensor : public Component {
   uint8_t levels_[MAX_BITS];
   uint16_t timings_[MAX_BITS];
   uint16_t bit_index_{0};
+
+  bool debug_{false};
 
   sensor::Sensor *temp_sensors_[6]{};
   binary_sensor::BinarySensor *relay_sensors_[4]{};

--- a/components/uvr64_dlbus/dlbus_sensor.py
+++ b/components/uvr64_dlbus/dlbus_sensor.py
@@ -10,11 +10,14 @@ DLBusSensor = uvr64_dlbus_ns.class_('DLBusSensor', cg.Component)
 CONF_TEMP_SENSORS = "temp_sensors"
 CONF_RELAY_SENSORS = "relay_sensors"
 
+CONF_DEBUG = "debug"
+
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(DLBusSensor),
     cv.Required(CONF_PIN): pins.internal_gpio_input_pin_schema,
     cv.Required(CONF_TEMP_SENSORS): cv.ensure_list(cv.use_id(sensor.Sensor)),
     cv.Required(CONF_RELAY_SENSORS): cv.ensure_list(cv.use_id(binary_sensor.BinarySensor)),
+    cv.Optional(CONF_DEBUG, default=False): cv.boolean,
 }).extend(cv.COMPONENT_SCHEMA)
 
 async def to_code(config):
@@ -31,3 +34,5 @@ async def to_code(config):
     for i, bsens in enumerate(config[CONF_RELAY_SENSORS]):
         bsens_var = await cg.get_variable(bsens)
         cg.add(var.set_relay_sensor(i, bsens_var))
+
+    cg.add(var.set_debug(config[CONF_DEBUG]))

--- a/tests/test_parse_frame.cpp
+++ b/tests/test_parse_frame.cpp
@@ -41,7 +41,8 @@ int main() {
   for (int i = 0; i < 6; i++) sensor.set_temp_sensor(i, &temps[i]);
   for (int i = 0; i < 4; i++) sensor.set_relay_sensor(i, &relays[i]);
 
-  uint8_t frame[16] = {
+  uint8_t frame[17] = {
+      0x20,        // device id
       0x00, 0xC8,  // 20.0°C
       0x00, 0xD7,  // 21.5°C
       0xFF, 0xF6,  // -1.0°C


### PR DESCRIPTION
## Summary
- add optional `debug` config option
- compute dynamic threshold for Manchester decoding
- validate frames for device id and length
- adjust test data to include device id

## Testing
- `make -C tests`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_6863aee73d988332a512a099718d9b11