### PR TITLE
Improve invalid frame logging

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/components/uvr64_dlbus/dlbus_sensor.cpp
@@ -198,15 +198,26 @@ void DLBusSensor::log_frame_(const std::vector<uint8_t> &frame) {
 }
 
 bool DLBusSensor::validate_frame_(const std::vector<uint8_t> &frame) {
+  bool valid = true;
   if (frame.size() != 17) {
     ESP_LOGW(TAG, "Frame length invalid: %u", static_cast<unsigned>(frame.size()));
-    return false;
-  }
-  if (frame[0] != 0x20) {
+    valid = false;
+  } else if (frame[0] != 0x20) {
     ESP_LOGW(TAG, "Invalid device id: 0x%02X", frame[0]);
-    return false;
+    valid = false;
   }
-  return true;
+
+  if (!valid) {
+    std::string out;
+    for (auto b : frame) {
+      char buf[8];
+      snprintf(buf, sizeof(buf), "%02X ", b);
+      out += buf;
+    }
+    ESP_LOGW(TAG, "Invalid frame content: %s", out.c_str());
+  }
+
+  return valid;
 }
 
 }  // namespace uvr64_dlbus


### PR DESCRIPTION
## Summary
- log the complete bus frame when validation fails

## Testing
- `make -C tests run`

------
https://chatgpt.com/codex/tasks/task_e_6863b1c01bfc8332bb8275e5adf24b4f