### PR TITLE
Revert recent Manchester decoder changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,19 +108,16 @@ Bit = 0 → Relais AUS
 1. **SYNC-Erkennung:**  
 → 320 ms HIGH (16 HIGH-Bits ohne Flanken)
 
-2. **Taktbasierte Dekodierung:**
-→ Nach Erkennen des SYNC wird ein interner Bit-Takt erzeugt und der Pegel in der zweiten Halbperiode jedes Bits abgetastet.
+2. **Manchester-Dekodierung:**  
+→ Jede Flanke → Halbbits → Bit zusammensetzen.
 
-3. **Fallback Manchester-Dekodierung:**
-→ Falls keine Synchronisation erkannt wird, erfolgt die klassische Auswertung über Pulsbreiten.
-
-4. **Bit-zu-Byte-Konverter:**
+3. **Bit-zu-Byte-Konverter:**  
 → Startbit → 8 Datenbits → Stopbit.
 
-5. **Rahmen-Pufferung:**
+4. **Rahmen-Pufferung:**  
 → Von SYNC bis SYNC als vollständiges Telegramm verarbeiten.
 
-6. **Datenparser:**
+5. **Datenparser:**  
 → Adressiert den Sender **0x20** (UVR64).  
 → Extrahiert Temperaturen, Relaiszustände und weitere Werte.
 

--- a/components/uvr64_dlbus/dlbus_sensor.cpp
+++ b/components/uvr64_dlbus/dlbus_sensor.cpp
@@ -113,15 +113,6 @@ bool DLBusSensor::decode_manchester_(std::vector<uint8_t> &result) {
   if (bit_index_ < 2)
     return false;
 
-  // Try clock-synchronized decoding first
-  if (decode_sync_(result)) {
-    if (debug_)
-      ESP_LOGD(TAG, "Clock based decode successful");
-    return true;
-  }
-  if (debug_)
-    ESP_LOGD(TAG, "Clock sync failed, falling back to pulse decode");
-
   uint16_t min_t = UINT16_MAX;
   uint16_t max_t = 0;
   for (uint16_t i = 0; i < bit_index_; i++) {
@@ -132,125 +123,25 @@ bool DLBusSensor::decode_manchester_(std::vector<uint8_t> &result) {
       max_t = t;
   }
 
-  double avg_short = static_cast<double>(min_t);
-  double avg_long = static_cast<double>(max_t);
-  double threshold = (avg_short + avg_long) / 2.0;
-
+  double threshold = (static_cast<double>(min_t) + static_cast<double>(max_t)) / 2.0;
   size_t bit_pos = 0;
-  size_t errors = 0;
-
   for (size_t i = 0; i + 1 < bit_index_; i += 2) {
-    bool first_long = std::abs(static_cast<double>(timings_[i]) - avg_long) <
-                       std::abs(static_cast<double>(timings_[i]) - avg_short);
-    if (first_long)
-      avg_long = (avg_long * 7.0 + timings_[i]) / 8.0;
-    else
-      avg_short = (avg_short * 7.0 + timings_[i]) / 8.0;
+    bool first_long = static_cast<double>(timings_[i]) >= threshold;
+    bool second_long = static_cast<double>(timings_[i + 1]) >= threshold;
 
-    threshold = (avg_short + avg_long) / 2.0;
-
-    bool second_long = std::abs(static_cast<double>(timings_[i + 1]) - avg_long) <
-                        std::abs(static_cast<double>(timings_[i + 1]) - avg_short);
-    if (second_long)
-      avg_long = (avg_long * 7.0 + timings_[i + 1]) / 8.0;
-    else
-      avg_short = (avg_short * 7.0 + timings_[i + 1]) / 8.0;
-
-    threshold = (avg_short + avg_long) / 2.0;
-
-    bool bit;
     if (first_long == second_long) {
-      errors++;
-      bit = timings_[i] < timings_[i + 1];
       if (debug_)
-        ESP_LOGD(TAG,
-                 "Invalid Manchester pair at %zu: %d/%d (th=%.1f short=%.1f long=%.1f errors=%zu)",
-                 i, timings_[i], timings_[i + 1], threshold, avg_short, avg_long, errors);
-      if (errors > 3)
-        return false;
-    } else {
-      bit = second_long;
+        ESP_LOGD(TAG, "Invalid Manchester pair at %zu: %d/%d", i, timings_[i], timings_[i + 1]);
+      return false;
     }
 
+    bool bit = second_long;
     if (bit_pos % 8 == 0)
       result.push_back(0);
 
     result.back() = (result.back() << 1) | (bit ? 1 : 0);
     bit_pos++;
   }
-
-  if (result.empty())
-    return false;
-
-  if (result[0] != 0x20) {
-    for (size_t idx = 1; idx < result.size(); idx++) {
-      if (result[idx] == 0x20 && result.size() - idx >= 17) {
-        if (debug_)
-          ESP_LOGD(TAG, "Resynchronized at byte %zu", idx);
-        result.erase(result.begin(), result.begin() + idx);
-        break;
-      }
-    }
-  }
-
-  return !result.empty();
-}
-
-bool DLBusSensor::decode_sync_(std::vector<uint8_t> &result) {
-  if (bit_index_ < 2)
-    return false;
-
-  std::vector<uint32_t> times(bit_index_);
-  uint32_t t = 0;
-  for (size_t i = 0; i < bit_index_; i++) {
-    t += timings_[i];
-    times[i] = t;
-  }
-
-  size_t sync_idx = SIZE_MAX;
-  for (size_t i = 0; i < bit_index_; i++) {
-    if (timings_[i] >= SYNC_MIN_US) {
-      sync_idx = i;
-      break;
-    }
-  }
-
-  if (sync_idx == SIZE_MAX || sync_idx + 1 >= bit_index_)
-    return false;
-
-  const uint32_t BIT_US = 20000;
-  const uint32_t SAMPLE_OFFSET_US = 15000;  // middle of second half
-
-  uint32_t frame_start = times[sync_idx];
-  size_t edge_ptr = sync_idx + 1;
-  bool level = levels_[sync_idx];
-  uint32_t next_edge_time = edge_ptr < bit_index_ ? times[edge_ptr] : UINT32_MAX;
-
-  size_t bit_pos = 0;
-  uint32_t total_time = times.back();
-
-  while (true) {
-    uint32_t sample_time = frame_start + SAMPLE_OFFSET_US + bit_pos * BIT_US;
-    if (sample_time >= total_time)
-      break;
-
-    while (edge_ptr < bit_index_ && next_edge_time <= sample_time) {
-      level = levels_[edge_ptr];
-      edge_ptr++;
-      next_edge_time = edge_ptr < bit_index_ ? times[edge_ptr] : UINT32_MAX;
-    }
-
-    if (bit_pos % 8 == 0)
-      result.push_back(0);
-    result.back() = (result.back() << 1) | (level ? 1 : 0);
-
-    bit_pos++;
-    if (bit_pos > 17 * 8)
-      break;
-  }
-
-  if (debug_ && !result.empty())
-    ESP_LOGD(TAG, "SYNC detected, decoded %zu bits in clock mode", bit_pos);
 
   return !result.empty();
 }

--- a/components/uvr64_dlbus/dlbus_sensor.h
+++ b/components/uvr64_dlbus/dlbus_sensor.h
@@ -10,7 +10,6 @@ namespace esphome {
 namespace uvr64_dlbus {
 
 static const uint32_t FRAME_TIMEOUT_US = 100000;  // 100ms
-static const uint32_t SYNC_MIN_US = 250000;       // 250ms, used for sync detection
 static const int MAX_BITS = 1024;
 
 class DLBusSensor : public Component {
@@ -36,7 +35,6 @@ class DLBusSensor : public Component {
   void parse_frame_();
   void log_frame_(const std::vector<uint8_t> &frame);
   bool decode_manchester_(std::vector<uint8_t> &result);
-  bool decode_sync_(std::vector<uint8_t> &result);
   void log_bits_();
   bool validate_frame_(const std::vector<uint8_t> &frame);
 

--- a/components/uvr64_dlbus/dlbus_sensor.py
+++ b/components/uvr64_dlbus/dlbus_sensor.py
@@ -25,7 +25,7 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID], pin)
     await cg.register_component(var, config)
 
-    #cg.add(var.set_pin(pin))
+    cg.add(var.set_pin(pin))
 
     for i, sens in enumerate(config[CONF_TEMP_SENSORS]):
         sens_var = await cg.get_variable(sens)

--- a/components/uvr64_dlbus/manifest.json
+++ b/components/uvr64_dlbus/manifest.json
@@ -7,5 +7,5 @@
     "dlbus_sensor.py",
     "__init__.py"
   ],
-  "dependencies": ["esphome", "sensor", "binary_sensor"]
+  "dependencies": ["sensor", "binary_sensor"]
 }


### PR DESCRIPTION
## Summary
- revert `Update dlbus_sensor.py`
- revert `Update manifest.json`
- revert clock-synchronized Manchester decoder
- revert adaptive Manchester decoder improvements

## Testing
- `cd tests && make clean && make && make run`

------
https://chatgpt.com/codex/tasks/task_e_68649b02804883328a58dca25939292f