### PR TITLE
Fix sensor list length validation

### DIFF
--- a/components/uvr64_dlbus/dlbus_sensor.py
+++ b/components/uvr64_dlbus/dlbus_sensor.py
@@ -15,8 +15,14 @@ CONF_DEBUG = "debug"
 CONFIG_SCHEMA = cv.Schema({
     cv.GenerateID(): cv.declare_id(DLBusSensor),
     cv.Required(CONF_PIN): pins.internal_gpio_input_pin_schema,
-    cv.Required(CONF_TEMP_SENSORS): cv.ensure_list(cv.use_id(sensor.Sensor)),
-    cv.Required(CONF_RELAY_SENSORS): cv.ensure_list(cv.use_id(binary_sensor.BinarySensor)),
+    cv.Required(CONF_TEMP_SENSORS): cv.All(
+        cv.ensure_list(cv.use_id(sensor.Sensor)),
+        cv.Length(min=6, max=6, msg="Exactly 6 temp_sensors must be specified"),
+    ),
+    cv.Required(CONF_RELAY_SENSORS): cv.All(
+        cv.ensure_list(cv.use_id(binary_sensor.BinarySensor)),
+        cv.Length(min=4, max=4, msg="Exactly 4 relay_sensors must be specified"),
+    ),
     cv.Optional(CONF_DEBUG, default=False): cv.boolean,
 }).extend(cv.COMPONENT_SCHEMA)
 


### PR DESCRIPTION
## Summary
- enforce exactly six temp_sensors and four relay_sensors in CONFIG_SCHEMA
- update validation messages

## Testing
- `make -C tests`
- `make -C tests run`


------
https://chatgpt.com/codex/tasks/task_e_68661693aa1883329e17f1e066923f22